### PR TITLE
Enable PRC by default

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -56,7 +56,9 @@ func makeDataSource(mod string, res string) tokens.ModuleMember {
 // Provider returns additional overlaid schema and metadata associated with the provider..
 func Provider() tfbridge.ProviderInfo {
 	// Instantiate the Terraform provider
-	p := shimv2.NewProvider(snowflake.Provider())
+	p := shimv2.NewProvider(snowflake.Provider(),
+		shimv2.WithPlanResourceChange(func(_ string) bool { return true }),
+	)
 
 	// Create a Pulumi provider mapping
 	prov := tfbridge.ProviderInfo{


### PR DESCRIPTION
This enables PlanResourceChange by default for the provider.

Part of https://github.com/pulumi/pulumi-terraform-bridge/issues/1785

fixes https://github.com/pulumi/pulumi-snowflake/issues/673

I've been unable to get a regression test working for 673 as upgrade tests don't work for the resource - it seems to access the cloud API during preview and does an implicit refresh it looks like. I've test manually and the issue is fixed.